### PR TITLE
(test): array of custom types

### DIFF
--- a/test/encoder.spec.js
+++ b/test/encoder.spec.js
@@ -58,6 +58,49 @@ describe('encoder', () => {
       ).to.throw()
     })
 
+    it('roundtrips an array of custom types', () => {
+      class Foo {
+        constructor (data) {
+          this.data = data
+        }
+      }
+
+      function encodeFoo (enc, foo) {
+        enc.pushAny(new cbor.Tagged(12345, foo.data))
+      }
+
+      function decodeFoo (data) {
+        return new Foo(data)
+      }
+
+      const encoder = new cbor.Encoder({
+        genTypes: [
+          [Foo, encodeFoo]
+        ]
+      })
+
+      const decoder = new cbor.Decoder({
+        tags: {
+          12345: decodeFoo
+        }
+      })
+
+      const input = [
+        new Foo('hello'),
+        new Foo('world')
+      ]
+
+      encoder.pushAny(input)
+      const serialized = encoder.finalize()
+      const deserialized = decoder.decodeFirst(serialized)
+
+      expect(
+        deserialized
+      ).to.be.eql(
+        input
+      )
+    })
+
     it('addSemanticType', () => {
       // before the tag, this is an innocuous object:
       // {"value": "foo"}


### PR DESCRIPTION
Fails with:

```
1) encoder misc roundtrips an array of custom types:
     Error: Undeterminated nesting
      at Decoder._decode (src/decoder.js:560:15)
      at Decoder.decodeFirst (src/decoder.js:576:10)
      at Context.it (test/encoder.spec.js:95:36)
```

Curiously, it passes if there's only one Foo in the input array.