### PR TITLE
Fix Date object encoding as unix epoch

### DIFF
--- a/src/encoder.js
+++ b/src/encoder.js
@@ -231,6 +231,10 @@ class Encoder {
   }
 
   _pushDate (gen, obj) {
+    // Round date, to get seconds since 1970-01-01 00:00:00 as defined in
+    // Sec. 2.4.1 and get a possibly more compact encoding. Note that it is
+    // still allowed to encode fractions of seconds which can be achieved by
+    // changing overwriting the encode function for Date objects.
     return gen._pushTag(TAG.DATE_EPOCH) && gen.pushAny(Math.round(obj / 1000))
   }
 

--- a/src/encoder.js
+++ b/src/encoder.js
@@ -231,7 +231,7 @@ class Encoder {
   }
 
   _pushDate (gen, obj) {
-    return gen._pushTag(TAG.DATE_EPOCH) && gen.pushAny(obj / 1000)
+    return gen._pushTag(TAG.DATE_EPOCH) && gen.pushAny(Math.round(obj / 1000))
   }
 
   _pushBuffer (gen, obj) {

--- a/test/fixtures/vectors.js
+++ b/test/fixtures/vectors.js
@@ -638,5 +638,20 @@ module.exports = [
       Fun: true,
       Amt: -2
     }
+  },
+  {
+    cbor: 'wRpatNH6',
+    hex: 'c11a5ab4d1fa',
+    roundtrip: true,
+    decoded: new Date(1521799674000),
+  },
+  // test that encoder saves dates as seconds since 1970-01-01 00:00:00
+  // don't test with decoder as fractions of seconds are also allowed in date tags
+  {
+    cbor: 'wRpatNH6',
+    hex: 'c11a5ab4d1fa',
+    roundtrip: true,
+    diagnostic: true,
+    decoded: new Date(1521799674001)
   }
 ]

--- a/test/fixtures/vectors.js
+++ b/test/fixtures/vectors.js
@@ -643,7 +643,7 @@ module.exports = [
     cbor: 'wRpatNH6',
     hex: 'c11a5ab4d1fa',
     roundtrip: true,
-    decoded: new Date(1521799674000),
+    decoded: new Date(1521799674000)
   },
   // test that encoder saves dates as seconds since 1970-01-01 00:00:00
   // don't test with decoder as fractions of seconds are also allowed in date tags


### PR DESCRIPTION
The encoder function for Date objects saved a float value instead of an int due to the division by 1000. By using Math.round, the value float is converted to an int.