### PR TITLE
Avoid object allocation when creating strings from the underlying buffer

### DIFF
--- a/src/decoder.js
+++ b/src/decoder.js
@@ -31,6 +31,7 @@ class Decoder {
     // Heap use to share the input with the parser
     this._heap = new ArrayBuffer(opts.size)
     this._heap8 = new Uint8Array(this._heap)
+    this._buffer = Buffer.from(this._heap)
 
     this._reset()
 
@@ -354,9 +355,7 @@ class Decoder {
       return ''
     }
 
-    return (
-      Buffer.from(this._heap.slice(start, end))
-    ).toString('utf8')
+    return this._buffer.toString('utf8', start, end)
   }
 
   createSimpleUnassigned (val) {


### PR DESCRIPTION
For me this makes a significant difference WRT decoding performance, since fewer short lived copies of ~strings~buffers are being created.

See https://gist.github.com/rklaehn/ba52f94896788a67107e3d38fc37a498