### PR TITLE
feat: do not copy memory when Uint8Array is pushed

### DIFF
--- a/src/encoder.js
+++ b/src/encoder.js
@@ -404,7 +404,7 @@ class Encoder {
       case 'Array':
         return this._pushArray(this, obj)
       case 'Uint8Array':
-        return this._pushBuffer(this, Buffer.isBuffer(obj) ? obj : Buffer.from(obj))
+        return this._pushBuffer(this, Buffer.isBuffer(obj) ? obj : Buffer.from(obj.buffer, obj.byteOffset, obj.byteLength))
       case 'Null':
         return this._pushUInt8(NULL)
       case 'Undefined':


### PR DESCRIPTION
Current implementation will copy memory if `Uint8Array` is pushed. Proposed change avoids unnecessary coping by creating a Buffer view of the underlying `ArrayBuffer` instead.